### PR TITLE
Fix broken dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
         "url": "https://github.com/dotdoom/gitbook-plugin-viz.js/issues"
     },
     "dependencies": {
-        "viz.js": ">=1.3.0"
+        "viz.js": "^1.3.0"
     }
 }


### PR DESCRIPTION
Viz.js 2.0 has been published with breaking changes. The dependency will pull in the new version, which breaks the plugin.

This PR fixes the version to v1.